### PR TITLE
fix postgres version

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -160,7 +160,7 @@ module "rds" {
   version                             = "5.1.1"
   count                               = var.deploy_rds_db ? 1 : 0
   engine                              = "postgres"
-  engine_version                      = "13.7"
+  engine_version                      = "13.10"
   family                              = "postgres13"
   major_engine_version                = "13"
   instance_class                      = var.rds_instance_type


### PR DESCRIPTION
The latest run of our staging action failed: https://github.com/omni-network/omni/actions/runs/5660761355/job/15337190325

Our testnet postgres version had been upgraded to 13.10, while it remained at 13.7 in our config, so when the above action ran terraform apply, it tried to downgrade the version back to 13.7 (not possible, so it failed). This PR updates our config to use 13.10 across the board.