### PR TITLE
feat: updated staging image to use the actual latest image builds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  blockscout_docker_image = "omniops/blockscout:5.1.5-omnibeta.1"
+  blockscout_dev_docker_image = "omniops/blockscout:dev"
 }
 
 provider "aws" {
@@ -26,7 +26,7 @@ module "obs_staging_vpc" {
     config       = "staging"
   }
   blockscout_settings = {
-    blockscout_docker_image = blockscout_docker_image
+    blockscout_docker_image = blockscout_dev_docker_image
     rpc_address             = "http://staging.omni.network:8545"
     ws_address              = "ws://staging.omni.network:8546"
     chain_id                = "165"


### PR DESCRIPTION
We were not using the latest builds of the blockscout ui in staging rather a tagged version. This fixes it to use the latest build image in UI