### PR TITLE
refactor: set docker image as var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,15 @@ resource "cloudflare_record" "staging_cname" {
   allow_overwrite = true
 }
 
+resource "cloudflare_record" "testnet_cname" {
+  zone_id         = var.cloudflare_zone_id
+  name            = "testnet.explorer"
+  type            = "CNAME"
+  proxied         = false
+  value           = module.obs_testnet_vpc.blockscout_url
+  allow_overwrite = true
+}
+
 resource "cloudflare_record" "staging_xchain_cname" {
   zone_id         = var.cloudflare_zone_id
   name            = "staging-xapi.explorer"
@@ -106,21 +115,12 @@ resource "cloudflare_record" "staging_xchain_cname" {
   allow_overwrite = true
 }
 
-resource "cloudflare_record" "testnet_cname" {
-  zone_id         = var.cloudflare_zone_id
-  name            = "testnet.explorer"
-  type            = "CNAME"
-  proxied         = false
-  value           = module.obs_testnet_vpc.blockscout_url
-  allow_overwrite = true
-}
-
 resource "cloudflare_record" "testnet_xchain_cname" {
   zone_id         = var.cloudflare_zone_id
   name            = "testnet-xapi.explorer"
   type            = "CNAME"
   proxied         = false
-  value           = module.obs_testnet_vpc[0].xchain_url
+  value           = module.obs_testnet_vpc.xchain_url
   allow_overwrite = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,15 @@ resource "cloudflare_record" "testnet_cname" {
   allow_overwrite = true
 }
 
+resource "cloudflare_record" "testnet_xchain_cname" {
+  zone_id         = var.cloudflare_zone_id
+  name            = "testnet-xapi.explorer"
+  type            = "CNAME"
+  proxied         = false
+  value           = module.obs_testnet_vpc[0].xchain_url
+  allow_overwrite = true
+}
+
 output "staging_blockscout_url" {
   value = var.deploy_staging_blockscout ? module.obs_staging_vpc[0].blockscout_url : null
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-locals {
-  blockscout_dev_docker_image = "omniops/blockscout:latest"
-}
-
 provider "aws" {
   region = "us-east-1"
 }
@@ -22,11 +18,11 @@ module "obs_staging_vpc" {
   deploy_rds_db                          = true
   xchain_settings = {
     enabled      = true
-    docker_image = "omniops/xchain-indexer:latest"
+    docker_image = var.xchain_indexer_docker_image
     config       = "staging"
   }
   blockscout_settings = {
-    blockscout_docker_image = local.blockscout_dev_docker_image
+    blockscout_docker_image = var.blockscout_dev_docker_image
     rpc_address             = "http://staging.omni.network:8545"
     ws_address              = "ws://staging.omni.network:8546"
     chain_id                = "165"
@@ -59,11 +55,11 @@ module "obs_testnet_vpc" {
   deploy_rds_db                          = true
   xchain_settings = {
     enabled      = true
-    docker_image = "omniops/xchain-indexer:latest"
+    docker_image = var.xchain_indexer_docker_image
     config       = "testnet"
   }
   blockscout_settings = {
-    blockscout_docker_image = local.blockscout_dev_docker_image
+    blockscout_docker_image = var.blockscout_dev_docker_image
     rpc_address             = "http://testnet-sentry-explorer.omni.network:8545"
     ws_address              = "ws://testnet-sentry-explorer.omni.network:8546"
     chain_id                = "165"

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ module "obs_staging_vpc" {
     config       = "staging"
   }
   blockscout_settings = {
-    blockscout_docker_image = var.blockscout_dev_docker_image
+    blockscout_docker_image = var.blockscout_docker_image
     rpc_address             = "http://staging.omni.network:8545"
     ws_address              = "ws://staging.omni.network:8546"
     chain_id                = "165"
@@ -59,7 +59,7 @@ module "obs_testnet_vpc" {
     config       = "testnet"
   }
   blockscout_settings = {
-    blockscout_docker_image = var.blockscout_dev_docker_image
+    blockscout_docker_image = var.blockscout_docker_image
     rpc_address             = "http://testnet-sentry-explorer.omni.network:8545"
     ws_address              = "ws://testnet-sentry-explorer.omni.network:8546"
     chain_id                = "165"

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,15 @@ variable "deploy_staging_blockscout" {
   type        = bool
   default     = true
 }
+
+variable "blockscout_docker_image" {
+  description = "The blockscout docker image."
+  type        = string
+  default     = "omniops/blockscout:latest"
+}
+
+variable "xchain_indexer_docker_image" {
+  description = "The xchain indexer docker image."
+  type        = string
+  default     = "omniops/xchain-indexer:latest"
+}


### PR DESCRIPTION
Instead of using a local string this should let us set the docker image dynamically in github workflows. However I'm not familiar with best practices around docker images in terraform, e.g. will this trigger a destroy and redeploy even if the variable hasn't changed since the last deployment?