### PR TITLE
add flag to deploy testnet explorer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ module "obs_staging_vpc" {
 
 module "obs_testnet_vpc" {
   source                                 = "./aws"
+  count                                  = var.deploy_testnet_blockscout ? 1 : 0
   vpc_name                               = "obs-testnet"
   vpc_cidr                               = "10.105.0.0/16"
   ssl_certificate_arn                    = var.ssl_certificate_arn
@@ -97,7 +98,8 @@ resource "cloudflare_record" "testnet_cname" {
   name            = "testnet.explorer"
   type            = "CNAME"
   proxied         = false
-  value           = module.obs_testnet_vpc.blockscout_url
+  count           = var.deploy_testnet_blockscout ? 1 : 0
+  value           = var.deploy_testnet_blockscout ? module.obs_testnet_vpc[0].blockscout_url : null
   allow_overwrite = true
 }
 
@@ -116,7 +118,8 @@ resource "cloudflare_record" "testnet_xchain_cname" {
   name            = "testnet-xapi.explorer"
   type            = "CNAME"
   proxied         = false
-  value           = module.obs_testnet_vpc.xchain_url
+  count           = var.deploy_testnet_blockscout ? 1 : 0
+  value           = var.deploy_testnet_blockscout ? module.obs_testnet_vpc[0].xchain_url : null
   allow_overwrite = true
 }
 
@@ -125,5 +128,5 @@ output "staging_blockscout_url" {
 }
 
 output "testnet_blockscout_url" {
-  value = module.obs_testnet_vpc.blockscout_url
+  value = var.deploy_testnet_blockscout ? module.obs_testnet_vpc[0].blockscout_url : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "deploy_staging_blockscout" {
   default     = true
 }
 
+variable "deploy_testnet_blockscout" {
+  description = "Whether to deploy the testnet blockscout service."
+  type        = bool
+  default     = true
+}
+
 variable "blockscout_docker_image" {
   description = "The blockscout docker image."
   type        = string


### PR DESCRIPTION
Didn't want to do this initially because I liked the added friction of manual changes if we wanted to take the testnet explorer down. But I've had to do this enough times in the past 2 days that I no longer like it. And we'll have to do it plenty more in the next week such that it's worth the ease here