### PR TITLE
WIP- Move x-chain indexer config from json to terraform variables

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -475,13 +475,14 @@ module "ec2_asg_xchain_indexer" {
   user                        = var.user
   security_groups             = module.application_sg.security_group_id
   docker_compose_config = {
-    postgres_password   = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
-    postgres_user       = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
-    xchain_docker_image = var.xchain_settings["docker_image"]
-    xchain_config       = var.xchain_settings["config"]
-    postgres_host       = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
-    api                 = false
-    indexer             = true
+    postgres_password    = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
+    postgres_user        = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
+    xchain_docker_image  = var.xchain_settings["docker_image"]
+    xchain_config        = var.xchain_settings["config"]
+    omni_config_rpc_addr = var.xchain_settings["omni_config"]["rpc_addr"]
+    postgres_host        = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
+    api                  = false
+    indexer              = true
   }
   tags = local.final_tags
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -479,7 +479,7 @@ module "ec2_asg_xchain_indexer" {
     postgres_user        = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_docker_image  = var.xchain_settings["docker_image"]
     xchain_config        = var.xchain_settings["config"]
-    omni_config_rpc_addr = var.xchain_settings["omni_config"]["rpc_addr"]
+    omni_rpc = var.xchain_settings["omni_config"]["rpc_addr"]
     postgres_host        = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                  = false
     indexer              = true

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -16,6 +16,7 @@ services:
             - /bin/indexer
             - index
             - --config-file=/config/${xchain_config}.json
+            - --omni-indexer-rpc-address=${omni_config_rpc_addr}
 %{ endif ~}
             image: omniops/xchain-indexer:latest
             restart: always

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -16,7 +16,7 @@ services:
             - /bin/indexer
             - index
             - --config-file=/config/${xchain_config}.json
-            - --omni-indexer-rpc-address=${omni_config_rpc_addr}
+            - --omni-indexer-rpc-address=${omni_rpc}
 %{ endif ~}
             image: omniops/xchain-indexer:latest
             restart: always

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -16,7 +16,7 @@ services:
             - /bin/indexer
             - index
             - --config-file=/config/${xchain_config}.json
-            - --omni-indexer-rpc-address=${omni_rpc}
+            - --omni-rpc=${omni_rpc}
 %{ endif ~}
             image: omniops/xchain-indexer:latest
             restart: always

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,9 @@ module "obs_staging_vpc" {
     enabled      = true
     docker_image = var.xchain_indexer_docker_image
     config       = "staging"
+    omni_config = {
+      rpc_addr = var.staging_xchain_indexer_omni_config_rpc_addr
+    }
   }
   blockscout_settings = {
     blockscout_docker_image = var.staging_blockscout_docker_image

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,9 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
+locals {
+  omni_staging_rpc = "http://staging.omni.network:8545"
+}
 
 module "obs_staging_vpc" {
   source                                 = "./aws"
@@ -21,7 +24,7 @@ module "obs_staging_vpc" {
     docker_image = var.xchain_indexer_docker_image
     config       = "staging"
     omni_config = {
-      rpc_addr = var.staging_xchain_indexer_omni_config_rpc_addr
+      rpc_addr = locals.omni_staging_rpc
     }
   }
   blockscout_settings = {

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,9 @@ variable "xchain_indexer_docker_image" {
   type        = string
   default     = "omniops/xchain-indexer:latest"
 }
+
+variable "staging_xchain_indexer_omni_config_rpc_addr" {
+  description = "The rpc address used by the omni indexer on staging."
+  type        = string
+  default     = "http://staging.omni.network:8545"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -42,9 +42,3 @@ variable "xchain_indexer_docker_image" {
   type        = string
   default     = "omniops/xchain-indexer:latest"
 }
-
-variable "staging_xchain_indexer_omni_config_rpc_addr" {
-  description = "The rpc address used by the omni indexer on staging."
-  type        = string
-  default     = "http://staging.omni.network:8545"
-}


### PR DESCRIPTION
# Description

As part of exploring the project and the task of migrating away from configuration in JSON files for the indexer, i moved a single variable (omni config rpc address) to terraform without removing the old mechanism for loading config. The variable is now defined in variables.tf with a default value from the old config and is passed around in appropriate places.

This is not a complete PR - I just introduced the new approach for a single variable  so that the team members can validate the approach. If ok, i would push only this single var change to staging to verify nothing is broken before i migrate everything and ditch the old approach completely.

Please note i might have missed something - new to terraform and still unsure how to properly test this locally.

Related indexer PR is [here](https://github.com/omni-network/xchain-indexer/pull/13)

## Motivation and Context

Consolidating configuration in a single place - Terraform instead of having it around in various places and formats.

## How Has This Been Tested

Has not been tested locally.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- Please delete options that are not relevant. -->

- Refactor (maintain existing functionality but modify code structure)
