### PR TITLE
Fix terraform config after introducing omni_rpc variable

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -479,7 +479,7 @@ module "ec2_asg_xchain_indexer" {
     postgres_user        = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_docker_image  = var.xchain_settings["docker_image"]
     xchain_config        = var.xchain_settings["config"]
-    omni_rpc = var.xchain_settings["omni_config"]["rpc_addr"]
+    omni_rpc             = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host        = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                  = false
     indexer              = true
@@ -514,6 +514,7 @@ module "ec2_asg_xchain_api" {
     postgres_user       = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_docker_image = var.xchain_settings["docker_image"]
     xchain_config       = var.xchain_settings["config"]
+    omni_rpc             = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host       = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                 = true
     indexer             = false

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -148,6 +148,7 @@ variable "xchain_settings" {
     enabled                     = optional(bool, false)
     docker_image                = optional(string, "omniops/xchain-indexer:latest")
     config                      = optional(string, "staging")
+    omni_config                 = optional(object({ omni_rpc=string }), { omni_rpc="http://staging.omni.network:8545" })
   })
   default = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ provider "cloudflare" {
 
 locals {
   omni_staging_rpc = "http://staging.omni.network:8545"
+  omni_testnet_rpc = "https://testnet.omni.network"
 }
 
 module "obs_staging_vpc" {
@@ -24,7 +25,7 @@ module "obs_staging_vpc" {
     docker_image = var.xchain_indexer_docker_image
     config       = "staging"
     omni_config = {
-      rpc_addr = locals.omni_staging_rpc
+      omni_rpc = local.omni_staging_rpc
     }
   }
   blockscout_settings = {
@@ -65,6 +66,9 @@ module "obs_testnet_vpc" {
     enabled      = true
     docker_image = var.xchain_indexer_docker_image
     config       = "testnet"
+    omni_config = {
+      omni_rpc = local.omni_testnet_rpc
+    }
   }
   blockscout_settings = {
     blockscout_docker_image = var.testnet_blockscout_docker_image


### PR DESCRIPTION
Fixed various config errors after trying to run terraform apply locally. Changes mainly include extending the definition of xchain_settings variable, renaming rpc_addr to omni_rpc and applying the same vars to testnet module.