### PR TITLE
Separate docker images for staging and testnet for xhain indexer

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -475,14 +475,14 @@ module "ec2_asg_xchain_indexer" {
   user                        = var.user
   security_groups             = module.application_sg.security_group_id
   docker_compose_config = {
-    postgres_password   = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
-    postgres_user       = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
-    xchain_docker_image = var.xchain_settings["docker_image"]
-    xchain_config       = var.xchain_settings["config"]
-    omni_rpc            = var.xchain_settings["omni_config"]["omni_rpc"]
-    postgres_host       = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
-    api                 = false
-    indexer             = true
+    postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
+    postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
+    xchain_indexer_docker_image = var.xchain_settings["docker_image"]
+    xchain_config               = var.xchain_settings["config"]
+    omni_rpc                    = var.xchain_settings["omni_config"]["omni_rpc"]
+    postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
+    api                         = false
+    indexer                     = true
   }
   tags = local.final_tags
 }
@@ -510,14 +510,14 @@ module "ec2_asg_xchain_api" {
   user                        = var.user
   security_groups             = module.application_sg.security_group_id
   docker_compose_config = {
-    postgres_password   = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
-    postgres_user       = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
-    xchain_docker_image = var.xchain_settings["docker_image"]
-    xchain_config       = var.xchain_settings["config"]
-    omni_rpc            = var.xchain_settings["omni_config"]["omni_rpc"]
-    postgres_host       = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
-    api                 = true
-    indexer             = false
+    postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
+    postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
+    xchain_indexer_docker_image = var.xchain_settings["docker_image"]
+    xchain_config               = var.xchain_settings["config"]
+    omni_rpc                    = var.xchain_settings["omni_config"]["omni_rpc"]
+    postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
+    api                         = true
+    indexer                     = false
   }
   tags = local.final_tags
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -475,14 +475,14 @@ module "ec2_asg_xchain_indexer" {
   user                        = var.user
   security_groups             = module.application_sg.security_group_id
   docker_compose_config = {
-    postgres_password    = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
-    postgres_user        = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
-    xchain_docker_image  = var.xchain_settings["docker_image"]
-    xchain_config        = var.xchain_settings["config"]
-    omni_rpc             = var.xchain_settings["omni_config"]["omni_rpc"]
-    postgres_host        = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
-    api                  = false
-    indexer              = true
+    postgres_password   = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
+    postgres_user       = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
+    xchain_docker_image = var.xchain_settings["docker_image"]
+    xchain_config       = var.xchain_settings["config"]
+    omni_rpc            = var.xchain_settings["omni_config"]["omni_rpc"]
+    postgres_host       = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
+    api                 = false
+    indexer             = true
   }
   tags = local.final_tags
 }
@@ -514,7 +514,7 @@ module "ec2_asg_xchain_api" {
     postgres_user       = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_docker_image = var.xchain_settings["docker_image"]
     xchain_config       = var.xchain_settings["config"]
-    omni_rpc             = var.xchain_settings["omni_config"]["omni_rpc"]
+    omni_rpc            = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host       = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                 = true
     indexer             = false

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -18,7 +18,7 @@ services:
             - --config-file=/config/${xchain_config}.json
             - --omni-rpc=${omni_rpc}
 %{ endif ~}
-            image: ${xchain_docker_image}
+            image: ${xchain_indexer_docker_image}
             restart: always
             environment:
                   DB_HOST: ${postgres_host}

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -18,7 +18,7 @@ services:
             - --config-file=/config/${xchain_config}.json
             - --omni-rpc=${omni_rpc}
 %{ endif ~}
-            image: omniops/xchain-indexer:latest
+            image: ${xchain_docker_image}
             restart: always
             environment:
                   DB_HOST: ${postgres_host}

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,11 @@ provider "cloudflare" {
 */
 locals {
   omni_staging_rpc = "http://staging.omni.network:8545"
+  omni_staging_ws = "ws://staging.omni.network:8546"
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:latest"
   blockscout_staging_docker_image = "omniops/blockscout:latest"
   omni_testnet_rpc = "http://testnet-sentry-explorer.omni.network:8545"
+  omni_testnet_ws = "ws://testnet-sentry-explorer.omni.network:8546"
   xchain_indexer_testnet_docker_image = "omniops/xchain-indexer:master"
   blockscout_testnet_docker_image = "omniops/blockscout:master"
 }
@@ -40,7 +42,7 @@ module "obs_staging_vpc" {
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_staging_docker_image
     rpc_address             = local.omni_staging_rpc
-    ws_address              = "ws://staging.omni.network:8546"
+    ws_address              = local.omni_staging_ws
     chain_id                = "165"
     docker_shell            = "sh"
   }
@@ -82,7 +84,7 @@ module "obs_testnet_vpc" {
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_testnet_docker_image
     rpc_address             = local.omni_testnet_rpc
-    ws_address              = "ws://testnet-sentry-explorer.omni.network:8546"
+    ws_address              = local.omni_testnet_ws
     chain_id                = "165"
     docker_shell            = "sh"
   }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
   omni_staging_rpc = "http://staging.omni.network:8545"
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:latest"
   blockscout_staging_docker_image = "omniops/blockscout:latest"
-  omni_testnet_rpc = "https://testnet.omni.network"
+  omni_testnet_rpc = "http://testnet-sentry-explorer.omni.network:8545"
   xchain_indexer_testnet_docker_image = "omniops/xchain-indexer:master"
   blockscout_testnet_docker_image = "omniops/blockscout:master"
 }
@@ -34,7 +34,7 @@ module "obs_staging_vpc" {
   }
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_staging_docker_image
-    rpc_address             = "http://staging.omni.network:8545"
+    rpc_address             = local.omni_staging_rpc
     ws_address              = "ws://staging.omni.network:8546"
     chain_id                = "165"
     docker_shell            = "sh"
@@ -76,7 +76,7 @@ module "obs_testnet_vpc" {
   }
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_testnet_docker_image
-    rpc_address             = "http://testnet-sentry-explorer.omni.network:8545"
+    rpc_address             = local.omni_testnet_rpc
     ws_address              = "ws://testnet-sentry-explorer.omni.network:8546"
     chain_id                = "165"
     docker_shell            = "sh"

--- a/main.tf
+++ b/main.tf
@@ -22,14 +22,14 @@ module "obs_staging_vpc" {
   deploy_rds_db                          = true
   xchain_settings = {
     enabled      = true
-    docker_image = var.xchain_indexer_docker_image
+    docker_image = "omniops/xchain-indexer:latest"
     config       = "staging"
     omni_config = {
       omni_rpc = local.omni_staging_rpc
     }
   }
   blockscout_settings = {
-    blockscout_docker_image = var.staging_blockscout_docker_image
+    blockscout_docker_image = "omniops/blockscout:latest"
     rpc_address             = "http://staging.omni.network:8545"
     ws_address              = "ws://staging.omni.network:8546"
     chain_id                = "165"
@@ -64,14 +64,14 @@ module "obs_testnet_vpc" {
   deploy_rds_db                          = true
   xchain_settings = {
     enabled      = true
-    docker_image = var.xchain_indexer_docker_image
+    docker_image = "omniops/xchain-indexer:master"
     config       = "testnet"
     omni_config = {
       omni_rpc = local.omni_testnet_rpc
     }
   }
   blockscout_settings = {
-    blockscout_docker_image = var.testnet_blockscout_docker_image
+    blockscout_docker_image = "omniops/blockscout:master"
     rpc_address             = "http://testnet-sentry-explorer.omni.network:8545"
     ws_address              = "ws://testnet-sentry-explorer.omni.network:8546"
     chain_id                = "165"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,11 @@ provider "cloudflare" {
 
 locals {
   omni_staging_rpc = "http://staging.omni.network:8545"
+  xchain_indexer_staging_docker_image = "omniops/xchain-indexer:latest"
+  blockscout_staging_docker_image = "omniops/blockscout:latest"
   omni_testnet_rpc = "https://testnet.omni.network"
+  xchain_indexer_testnet_docker_image = "omniops/xchain-indexer:master"
+  blockscout_testnet_docker_image = "omniops/blockscout:master"
 }
 
 module "obs_staging_vpc" {
@@ -22,14 +26,14 @@ module "obs_staging_vpc" {
   deploy_rds_db                          = true
   xchain_settings = {
     enabled      = true
-    docker_image = "omniops/xchain-indexer:latest"
+    docker_image = local.xchain_indexer_staging_docker_image
     config       = "staging"
     omni_config = {
       omni_rpc = local.omni_staging_rpc
     }
   }
   blockscout_settings = {
-    blockscout_docker_image = "omniops/blockscout:latest"
+    blockscout_docker_image = local.blockscout_staging_docker_image
     rpc_address             = "http://staging.omni.network:8545"
     ws_address              = "ws://staging.omni.network:8546"
     chain_id                = "165"
@@ -64,14 +68,14 @@ module "obs_testnet_vpc" {
   deploy_rds_db                          = true
   xchain_settings = {
     enabled      = true
-    docker_image = "omniops/xchain-indexer:master"
+    docker_image = local.xchain_indexer_testnet_docker_image
     config       = "testnet"
     omni_config = {
       omni_rpc = local.omni_testnet_rpc
     }
   }
   blockscout_settings = {
-    blockscout_docker_image = "omniops/blockscout:master"
+    blockscout_docker_image = local.blockscout_testnet_docker_image
     rpc_address             = "http://testnet-sentry-explorer.omni.network:8545"
     ws_address              = "ws://testnet-sentry-explorer.omni.network:8546"
     chain_id                = "165"

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,11 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
+/* For each deployment of new docker images for xchain indexer and\or blockscout to any enviroment, 
+   make sure to use specific tag names in the vars given below (i.e "omniops/xchain-indexer:1.0.0") 
+  and to commit the change to the repo once the deployment has been executed. This is currently the only place
+  where we track which version of a docker image has been deployed to an enviroment.
+*/
 locals {
   omni_staging_rpc = "http://staging.omni.network:8545"
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:latest"

--- a/variables.tf
+++ b/variables.tf
@@ -24,21 +24,3 @@ variable "deploy_testnet_blockscout" {
   type        = bool
   default     = true
 }
-
-variable "staging_blockscout_docker_image" {
-  description = "The staging blockscout docker image."
-  type        = string
-  default     = "omniops/blockscout:latest"
-}
-
-variable "testnet_blockscout_docker_image" {
-  description = "The testnet blockscout docker image."
-  type        = string
-  default     = "omniops/blockscout:latest"
-}
-
-variable "xchain_indexer_docker_image" {
-  description = "The xchain indexer docker image."
-  type        = string
-  default     = "omniops/xchain-indexer:latest"
-}


### PR DESCRIPTION
Removes staging and testnet docker image variables from  blockscout terraform config;
Introduces separate tags for staging and testnet environments for both images; 
Passes in xchain_docker_image var instead of hardcoded image to compose xchain template;


Tag names introduced are latest and master for staging and testnet respectively. Might be a better option to use specific tags such as version (i.e. 15.4) or digest (i.e. @sha256:905201222aff4338cd13910c627c3ec3c315b17c4e936964795d5e17f7214ee4) as we would then know the exact last version deployed.
