### PR TITLE
Mounting a terraform generated JSON config file to xchain indexer

### DIFF
--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -39,6 +39,7 @@ module "ec2_asg" {
         "${path.module}/../templates/docker_compose${var.docker_compose_file_postfix}.tftpl",
         var.docker_compose_config
       )
+      indexer_json_config       = var.indexer_json_config
       path_docker_compose_files = var.path_docker_compose_files
       user                      = var.user
     }

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -39,9 +39,9 @@ module "ec2_asg" {
         "${path.module}/../templates/docker_compose${var.docker_compose_file_postfix}.tftpl",
         var.docker_compose_config
       )
-      indexer_json_config       = var.indexer_json_config
-      path_docker_compose_files = var.path_docker_compose_files
-      user                      = var.user
+      xchain_config_file_content = var.xchain_config_file_content
+      path_docker_compose_files  = var.path_docker_compose_files
+      user                       = var.user
     }
   ))
   block_device_mappings = var.block_devices

--- a/aws/asg/variables.tf
+++ b/aws/asg/variables.tf
@@ -31,6 +31,10 @@ variable "iam_role_name" {
 variable "docker_compose_config" {
   type = any
 }
+variable "indexer_json_config" {
+  type = string
+  default = ""
+}
 variable "path_docker_compose_files" {
   type = string
 }

--- a/aws/asg/variables.tf
+++ b/aws/asg/variables.tf
@@ -31,7 +31,7 @@ variable "iam_role_name" {
 variable "docker_compose_config" {
   type = any
 }
-variable "indexer_json_config" {
+variable "xchain_config_file_content" {
   type = string
   default = ""
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -209,7 +209,8 @@ module "ec2_database" {
           postgres_password = var.blockscout_settings["postgres_password"]
           postgres_user     = var.blockscout_settings["postgres_user"]
         }
-      )
+      ),
+      indexer_json_config       = "TODO: not needed here, maybe the var can be marked as optional? in the template or a separate template introduced"
       path_docker_compose_files = var.path_docker_compose_files
       user                      = var.user
     }
@@ -484,6 +485,7 @@ module "ec2_asg_xchain_indexer" {
     api                         = false
     indexer                     = true
   }
+  indexer_json_config = var.xchain_settings["json_config"]
   tags = local.final_tags
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -479,7 +479,7 @@ module "ec2_asg_xchain_indexer" {
     postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
     postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_indexer_docker_image = var.xchain_settings["docker_image"]
-    xchain_config               = var.xchain_settings["config"]
+    xchain_config_file_name     = var.xchain_settings["config_file_name"]
     omni_rpc                    = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                         = false
@@ -515,7 +515,7 @@ module "ec2_asg_xchain_api" {
     postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
     postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_indexer_docker_image = var.xchain_settings["docker_image"]
-    xchain_config               = var.xchain_settings["config"]
+    xchain_config_file_name     = var.xchain_settings["config_file_name"]
     omni_rpc                    = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                         = true

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -210,9 +210,9 @@ module "ec2_database" {
           postgres_user     = var.blockscout_settings["postgres_user"]
         }
       ),
-      indexer_json_config       = "TODO: not needed here, maybe the var can be marked as optional? in the template or a separate template introduced"
-      path_docker_compose_files = var.path_docker_compose_files
-      user                      = var.user
+      xchain_config_file_content = "TODO: not needed here, maybe the var can be marked as optional? in the template or a separate template introduced"
+      path_docker_compose_files  = var.path_docker_compose_files
+      user                       = var.user
     }
   )
 }
@@ -485,7 +485,7 @@ module "ec2_asg_xchain_indexer" {
     api                         = false
     indexer                     = true
   }
-  indexer_json_config = var.xchain_settings["json_config"]
+  xchain_config_file_content  = var.xchain_settings["config_file_content"]
   tags = local.final_tags
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -210,7 +210,7 @@ module "ec2_database" {
           postgres_user     = var.blockscout_settings["postgres_user"]
         }
       ),
-      xchain_config_file_content = "TODO: not needed here, maybe the var can be marked as optional? in the template or a separate template introduced"
+      xchain_config_file_content = ""
       path_docker_compose_files  = var.path_docker_compose_files
       user                       = var.user
     }

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -18,7 +18,7 @@ services:
             - --config-file=/config/${xchain_config}.json
             - --omni-rpc=${omni_rpc}
             volumes:
-            - /config/config.json:/config/${xchain_config}.json
+            - /config/config.json:/config/config.json
 %{ endif ~}
             image: ${xchain_indexer_docker_image}
             restart: always

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -17,6 +17,8 @@ services:
             - index
             - --config-file=/config/${xchain_config}.json
             - --omni-rpc=${omni_rpc}
+            volumes:
+            - /config/config.json:/config/${xchain_config}.json
 %{ endif ~}
             image: ${xchain_indexer_docker_image}
             restart: always

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -6,7 +6,7 @@ services:
             entrypoint:
             - /bin/indexer
             - api
-            - --config-file=/config/${xchain_config}.json
+            - --config-file=/config/${xchain_config_file_name}.json
             - --port=4000
 %{ endif ~}
 %{ if indexer ~}
@@ -15,7 +15,7 @@ services:
             entrypoint:
             - /bin/indexer
             - index
-            - --config-file=/config/${xchain_config}.json
+            - --config-file=/config/${xchain_config_file_name}.json
             - --omni-rpc=${omni_rpc}
             volumes:
             - /config/config.json:/config/config.json

--- a/aws/templates/init_script.tftpl
+++ b/aws/templates/init_script.tftpl
@@ -17,6 +17,10 @@ mkdir -p $DEST
 cat > $DEST/docker-compose.yml <<-TEMPLATE
 ${docker_compose_str}
 TEMPLATE
+mkdir -p config
+cat > /config/config.json <<-TEMPLATE
+${indexer_json_config}
+TEMPLATE
 cat > /etc/systemd/system/docker_compose_service.service <<-TEMPLATE
 [Unit]
 Description=Service for starting docker-compose for blockscout

--- a/aws/templates/init_script.tftpl
+++ b/aws/templates/init_script.tftpl
@@ -19,7 +19,7 @@ ${docker_compose_str}
 TEMPLATE
 mkdir -p config
 cat > /config/config.json <<-TEMPLATE
-${indexer_json_config}
+${xchain_config_file_content}
 TEMPLATE
 cat > /etc/systemd/system/docker_compose_service.service <<-TEMPLATE
 [Unit]

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -148,6 +148,7 @@ variable "xchain_settings" {
     enabled                     = optional(bool, false)
     docker_image                = optional(string, "omniops/xchain-indexer:latest")
     config                      = optional(string, "staging")
+    json_config                 = optional(string, "")
     omni_config                 = optional(object({ omni_rpc=string }), { omni_rpc="http://staging.omni.network:8545" })
   })
   default = {}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -148,7 +148,7 @@ variable "xchain_settings" {
     enabled                     = optional(bool, false)
     docker_image                = optional(string, "omniops/xchain-indexer:latest")
     config_file_name            = optional(string, "staging")
-    json_config                 = optional(string, "")
+    config_file_content         = optional(string, "")
     omni_config                 = optional(object({ omni_rpc=string }), { omni_rpc="http://staging.omni.network:8545" })
   })
   default = {}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -147,7 +147,7 @@ variable "xchain_settings" {
   type = object({
     enabled                     = optional(bool, false)
     docker_image                = optional(string, "omniops/xchain-indexer:latest")
-    config                      = optional(string, "staging")
+    config_file_name            = optional(string, "staging")
     json_config                 = optional(string, "")
     omni_config                 = optional(object({ omni_rpc=string }), { omni_rpc="http://staging.omni.network:8545" })
   })

--- a/main.tf
+++ b/main.tf
@@ -12,16 +12,30 @@ provider "cloudflare" {
   where we track which version of a docker image has been deployed to an enviroment.
 */
 locals {
-  omni_staging_rpc = "http://staging.omni.network:8545"
   omni_staging_ws = "ws://staging.omni.network:8546"
+  omni_chain_config_staging = {
+    rpc_addr = "http://staging.omni.network:8545"
+    default_start_block = 0
+    confirmation_block_count = 0
+    syncInterval = 10
+    portal_addr = "0x1212400000000000000000000000000000000001"
+  }
   external_chains_staging = [
     {
-      chain_name = "testchainname",
-      rpc_addr = "testrpcaddress",
-      default_start_block = 0,
-      confirmation_block_count = 0,
-      syncInterval = 10
-      portal_addr = "testportaladdress"
+      chain_name = "chain-a"
+      rpc_addr = "http://staging.omni.network:6545"
+      default_start_block = -1
+      confirmation_block_count = 10
+      syncInterval = 30
+      portal_addr = "0x7965Bb94fD6129B4Ac9028243BeFA0fACe1d7286"
+    },
+    {
+      chain_name = "chain-b"
+      rpc_addr = "http://staging.omni.network:7545"
+      default_start_block = -1
+      confirmation_block_count = 10
+      syncInterval = 30
+      portal_addr = "0x7965Bb94fD6129B4Ac9028243BeFA0fACe1d7286"
     }
   ]
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:main"
@@ -42,24 +56,23 @@ module "obs_staging_vpc" {
   deploy_ec2_instance_db                 = false
   deploy_rds_db                          = true
   xchain_settings = {
-    enabled          = true
-    docker_image     = local.xchain_indexer_staging_docker_image
-    config_file_name = "config"
-    json_config      = jsonencode({
-      omni_config = {
-        rpc_addr = local.omni_staging_rpc
-      }
+    enabled             = true
+    docker_image        = local.xchain_indexer_staging_docker_image
+    config_file_name    = "config"
+    config_file_content = jsonencode({
+      omni_config = local.omni_chain_config_staging,
       external_chains = [
         for x_chain in local.external_chains_staging : x_chain
       ]
     })
+    # TODO: To be removed as soon as mounting config approach is tested on staging 
     omni_config      = {
-      omni_rpc = local.omni_staging_rpc
+      omni_rpc = local.omni_chain_config_staging.rpc_addr
     }
   }
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_staging_docker_image
-    rpc_address             = local.omni_staging_rpc
+    rpc_address             = local.omni_chain_config_staging.rpc_addr
     ws_address              = local.omni_staging_ws
     chain_id                = "165"
     docker_shell            = "sh"
@@ -92,10 +105,11 @@ module "obs_testnet_vpc" {
   deploy_ec2_instance_db                 = false
   deploy_rds_db                          = true
   xchain_settings = {
-    enabled          = true
-    docker_image     = local.xchain_indexer_testnet_docker_image
-    config_file_name = "testnet"
-    json_config      = "TODO"
+    enabled             = true
+    docker_image        = local.xchain_indexer_testnet_docker_image
+    config_file_name    = "testnet"
+    config_file_content = "TODO: apply staging approach as soon as it is tested"
+    # TODO: To be removed as soon as mounting config approach is tested on staging 
     omni_config      = {
       omni_rpc = local.omni_testnet_rpc
     }

--- a/main.tf
+++ b/main.tf
@@ -42,10 +42,10 @@ module "obs_staging_vpc" {
   deploy_ec2_instance_db                 = false
   deploy_rds_db                          = true
   xchain_settings = {
-    enabled      = true
-    docker_image = local.xchain_indexer_staging_docker_image
-    config       = "config"
-    json_config = jsonencode({
+    enabled          = true
+    docker_image     = local.xchain_indexer_staging_docker_image
+    config_file_name = "config"
+    json_config      = jsonencode({
       omni_config = {
         rpc_addr = local.omni_staging_rpc
       }
@@ -53,7 +53,7 @@ module "obs_staging_vpc" {
         for x_chain in local.external_chains_staging : x_chain
       ]
     })
-    omni_config = {
+    omni_config      = {
       omni_rpc = local.omni_staging_rpc
     }
   }
@@ -92,11 +92,11 @@ module "obs_testnet_vpc" {
   deploy_ec2_instance_db                 = false
   deploy_rds_db                          = true
   xchain_settings = {
-    enabled      = true
-    docker_image = local.xchain_indexer_testnet_docker_image
-    config       = "testnet"
-    json_config  = "TODO"
-    omni_config  = {
+    enabled          = true
+    docker_image     = local.xchain_indexer_testnet_docker_image
+    config_file_name = "testnet"
+    json_config      = "TODO"
+    omni_config      = {
       omni_rpc = local.omni_testnet_rpc
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,16 @@ provider "cloudflare" {
 locals {
   omni_staging_rpc = "http://staging.omni.network:8545"
   omni_staging_ws = "ws://staging.omni.network:8546"
+  external_chains_staging = [
+    {
+      chain_name = "testchainname",
+      rpc_addr = "testrpcaddress",
+      default_start_block = 0,
+      confirmation_block_count = 0,
+      syncInterval = 10
+      portal_addr = "testportaladdress"
+    }
+  ]
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:main"
   blockscout_staging_docker_image = "omniops/blockscout:0.1.0.commit.2404d446"
   omni_testnet_rpc = "http://testnet-sentry-explorer.omni.network:8545"
@@ -34,7 +44,15 @@ module "obs_staging_vpc" {
   xchain_settings = {
     enabled      = true
     docker_image = local.xchain_indexer_staging_docker_image
-    config       = "staging"
+    config       = "config"
+    json_config = jsonencode({
+      omni_config = {
+        rpc_addr = local.omni_staging_rpc
+      }
+      external_chains = [
+        for x_chain in local.external_chains_staging : x_chain
+      ]
+    })
     omni_config = {
       omni_rpc = local.omni_staging_rpc
     }
@@ -77,7 +95,8 @@ module "obs_testnet_vpc" {
     enabled      = true
     docker_image = local.xchain_indexer_testnet_docker_image
     config       = "testnet"
-    omni_config = {
+    json_config  = "TODO"
+    omni_config  = {
       omni_rpc = local.omni_testnet_rpc
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,49 @@ locals {
   ]
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:main"
   blockscout_staging_docker_image = "omniops/blockscout:0.1.0.commit.2404d446"
-  omni_testnet_rpc = "http://testnet-sentry-explorer.omni.network:8545"
+
   omni_testnet_ws = "ws://testnet-sentry-explorer.omni.network:8546"
+  omni_chain_config_testnet = {
+    rpc_addr = "http://testnet-sentry-explorer.omni.network:8545"
+    default_start_block = 0
+    confirmation_block_count = 0
+    syncInterval = 10
+    portal_addr = "0x1212400000000000000000000000000000000001"
+  }
+  external_chains_testnet = [
+    {
+      chain_name = "optimism-goerli"
+      rpc_addr = "https://optimism-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
+      default_start_block = -1
+      confirmation_block_count = 10
+      syncInterval = 30
+      portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
+    },
+    {
+      chain_name = "arbitrum-goerli"
+      rpc_addr = "https://arbitrum-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
+      default_start_block = -1
+      confirmation_block_count = 10
+      syncInterval = 30
+      portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
+    },
+    {
+      chain_name = "linea-goerli"
+      rpc_addr = "https://linea-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
+      default_start_block = -1
+      confirmation_block_count = 10
+      syncInterval = 30
+      portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
+    },
+    {
+      chain_name = "scroll-sepolia"
+      rpc_addr = "http://archive-node.sepolia.scroll.xyz:8545"
+      default_start_block = -1
+      confirmation_block_count = 10
+      syncInterval = 30
+      portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
+    }
+  ]
   xchain_indexer_testnet_docker_image = "omniops/xchain-indexer:latest"
   blockscout_testnet_docker_image = "omniops/blockscout:0.1.0.commit.2404d446"
 }
@@ -65,7 +106,6 @@ module "obs_staging_vpc" {
         for x_chain in local.external_chains_staging : x_chain
       ]
     })
-    # TODO: To be removed as soon as mounting config approach is tested on staging 
     omni_config      = {
       omni_rpc = local.omni_chain_config_staging.rpc_addr
     }
@@ -108,15 +148,19 @@ module "obs_testnet_vpc" {
     enabled             = true
     docker_image        = local.xchain_indexer_testnet_docker_image
     config_file_name    = "testnet"
-    config_file_content = "TODO: apply staging approach as soon as it is tested"
-    # TODO: To be removed as soon as mounting config approach is tested on staging 
+    config_file_content = jsonencode({
+      omni_config = local.omni_chain_config_testnet,
+      external_chains = [
+        for x_chain in local.external_chains_testnet : x_chain
+      ]
+    })
     omni_config      = {
-      omni_rpc = local.omni_testnet_rpc
+      omni_rpc = local.omni_chain_config_testnet.rpc_addr
     }
   }
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_testnet_docker_image
-    rpc_address             = local.omni_testnet_rpc
+    rpc_address             = local.omni_chain_config_testnet.rpc_addr
     ws_address              = local.omni_testnet_ws
     chain_id                = "165"
     docker_shell            = "sh"


### PR DESCRIPTION
JSON config is now generated using JSON encode, from local variables.

This JSON string is passed on to init_script template to create a config file on the ec2 instance.

This file is mounted to the config directory of the xchain indexer container as part of the docker compose template.

Change should would affect only staging environment during deployment, as the old mechanism is still in place.

Again, just a POC, if direction looks ok i would polish and test further.