### PR TITLE
Move config mount to happen always for indexer; Bump version of deployed staging x-indexer image;

### DIFF
--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -17,8 +17,6 @@ services:
             - index
             - --config-file=/config/${xchain_config_file_name}.json
             - --omni-rpc=${omni_rpc}
-            volumes:
-            - /config/config.json:/config/config.json
 %{ endif ~}
             image: ${xchain_indexer_docker_image}
             restart: always
@@ -28,5 +26,7 @@ services:
                   DB_NAME: blockscout
                   DB_USER: ${postgres_user}
                   DB_PASSWORD: ${postgres_password}
+            volumes:
+            - /config/config.json:/config/config.json
             ports:
             - 4000:4000

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ locals {
       portal_addr = "0x7965Bb94fD6129B4Ac9028243BeFA0fACe1d7286"
     }
   ]
-  xchain_indexer_staging_docker_image = "omniops/xchain-indexer:main"
+  xchain_indexer_staging_docker_image = "omniops/xchain-indexer:0.1.2"
   blockscout_staging_docker_image = "omniops/blockscout:0.1.0.commit.2404d446"
 
   omni_testnet_ws = "ws://testnet-sentry-explorer.omni.network:8546"


### PR DESCRIPTION
Config volume mount was happening only if indexer was being deployed. Now it happens both for indexer and api as they both depend on it.

Bumped tag xchain_indexer_staging_docker_image as it is the new version deployed to staging