### PR TITLE
add xchain config file content

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -521,6 +521,7 @@ module "ec2_asg_xchain_api" {
     api                         = true
     indexer                     = false
   }
+  xchain_config_file_content  = var.xchain_settings["config_file_content"]
   tags = local.final_tags
 }
 


### PR DESCRIPTION
We use this variable in staging for the xchain-indexer, but not the xchain-api. They are initialized using the same docker image, etc, so this content needs to be passed to both.

@ognjenkurtic I want to confirm the flow of data – it goes from the config in `/main.tf`, then is passed here and used in `aws/templates/init_script.tftpl`, which creates a json file on the volume with the relevant data, then when initializing that container, we specify that file to be used as the config.