### PR TITLE
Switch indexer fully to mount config approach

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -479,6 +479,7 @@ module "ec2_asg_xchain_indexer" {
     postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
     postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_indexer_docker_image = var.xchain_settings["docker_image"]
+    xchain_config_file_path     = var.xchain_settings["config_file_path"]
     postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                         = false
     indexer                     = true
@@ -513,6 +514,7 @@ module "ec2_asg_xchain_api" {
     postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
     postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_indexer_docker_image = var.xchain_settings["docker_image"]
+    xchain_config_file_path     = var.xchain_settings["config_file_path"]
     postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                         = true
     indexer                     = false

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -479,8 +479,6 @@ module "ec2_asg_xchain_indexer" {
     postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
     postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_indexer_docker_image = var.xchain_settings["docker_image"]
-    xchain_config_file_name     = var.xchain_settings["config_file_name"]
-    omni_rpc                    = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                         = false
     indexer                     = true
@@ -515,8 +513,6 @@ module "ec2_asg_xchain_api" {
     postgres_password           = var.deploy_rds_db ? module.rds[0].db_instance_password : var.blockscout_settings["postgres_password"]
     postgres_user               = var.deploy_rds_db ? module.rds[0].db_instance_username : var.blockscout_settings["postgres_user"]
     xchain_indexer_docker_image = var.xchain_settings["docker_image"]
-    xchain_config_file_name     = var.xchain_settings["config_file_name"]
-    omni_rpc                    = var.xchain_settings["omni_config"]["omni_rpc"]
     postgres_host               = var.deploy_rds_db ? module.rds[0].db_instance_address : module.ec2_database[0].private_dns
     api                         = true
     indexer                     = false

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -27,7 +27,7 @@ services:
                   DB_PASSWORD: ${postgres_password}
             volumes:
             - type: bind
-            source: /xchain-indexer-config-to-mount.json
+            source: /xchain_indexer_config_to_mount.json
             target: ${xchain_config_file_path}
             ports:
             - 4000:4000

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -6,7 +6,6 @@ services:
             entrypoint:
             - /bin/indexer
             - api
-            - --config-file=/config/${xchain_config_file_name}.json
             - --port=4000
 %{ endif ~}
 %{ if indexer ~}
@@ -15,8 +14,6 @@ services:
             entrypoint:
             - /bin/indexer
             - index
-            - --config-file=/config/${xchain_config_file_name}.json
-            - --omni-rpc=${omni_rpc}
 %{ endif ~}
             image: ${xchain_indexer_docker_image}
             restart: always

--- a/aws/templates/docker_compose_xchain.tftpl
+++ b/aws/templates/docker_compose_xchain.tftpl
@@ -6,6 +6,7 @@ services:
             entrypoint:
             - /bin/indexer
             - api
+            - --config-file=${xchain_config_file_path}
             - --port=4000
 %{ endif ~}
 %{ if indexer ~}
@@ -14,6 +15,7 @@ services:
             entrypoint:
             - /bin/indexer
             - index
+            - --config-file=${xchain_config_file_path}
 %{ endif ~}
             image: ${xchain_indexer_docker_image}
             restart: always
@@ -24,6 +26,8 @@ services:
                   DB_USER: ${postgres_user}
                   DB_PASSWORD: ${postgres_password}
             volumes:
-            - /config/config.json:/config/config.json
+            - type: bind
+            source: /xchain-indexer-config-to-mount.json
+            target: ${xchain_config_file_path}
             ports:
             - 4000:4000

--- a/aws/templates/init_script.tftpl
+++ b/aws/templates/init_script.tftpl
@@ -17,8 +17,7 @@ mkdir -p $DEST
 cat > $DEST/docker-compose.yml <<-TEMPLATE
 ${docker_compose_str}
 TEMPLATE
-mkdir -p config
-cat > /config/config.json <<-TEMPLATE
+cat > /xchain-indexer-config-to-mount.json <<-TEMPLATE
 ${xchain_config_file_content}
 TEMPLATE
 cat > /etc/systemd/system/docker_compose_service.service <<-TEMPLATE

--- a/aws/templates/init_script.tftpl
+++ b/aws/templates/init_script.tftpl
@@ -17,7 +17,7 @@ mkdir -p $DEST
 cat > $DEST/docker-compose.yml <<-TEMPLATE
 ${docker_compose_str}
 TEMPLATE
-cat > /xchain-indexer-config-to-mount.json <<-TEMPLATE
+cat > /xchain_indexer_config_to_mount.json <<-TEMPLATE
 ${xchain_config_file_content}
 TEMPLATE
 cat > /etc/systemd/system/docker_compose_service.service <<-TEMPLATE

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -147,9 +147,7 @@ variable "xchain_settings" {
   type = object({
     enabled                     = optional(bool, false)
     docker_image                = optional(string, "omniops/xchain-indexer:latest")
-    config_file_name            = optional(string, "staging")
     config_file_content         = optional(string, "")
-    omni_config                 = optional(object({ omni_rpc=string }), { omni_rpc="http://staging.omni.network:8545" })
   })
   default = {}
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -147,6 +147,7 @@ variable "xchain_settings" {
   type = object({
     enabled                     = optional(bool, false)
     docker_image                = optional(string, "omniops/xchain-indexer:latest")
+    config_file_path            = optional(string, "/config/config.json")
     config_file_content         = optional(string, "")
   })
   default = {}

--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,8 @@ locals {
     rpc_addr = "http://staging.omni.network:8545"
     default_start_block = 0
     confirmation_block_count = 0
-    syncInterval = 10
-    portal_addr = "0x1212400000000000000000000000000000000001"
+    sync_interval = 10
+    omni_predeploy_addr = "0x1212400000000000000000000000000000000001"
   }
   external_chains_staging = [
     {
@@ -26,7 +26,7 @@ locals {
       rpc_addr = "http://staging.omni.network:6545"
       default_start_block = -1
       confirmation_block_count = 10
-      syncInterval = 30
+      sync_interval = 30
       portal_addr = "0x7965Bb94fD6129B4Ac9028243BeFA0fACe1d7286"
     },
     {
@@ -34,7 +34,7 @@ locals {
       rpc_addr = "http://staging.omni.network:7545"
       default_start_block = -1
       confirmation_block_count = 10
-      syncInterval = 30
+      sync_interval = 30
       portal_addr = "0x7965Bb94fD6129B4Ac9028243BeFA0fACe1d7286"
     }
   ]
@@ -46,8 +46,8 @@ locals {
     rpc_addr = "http://testnet-sentry-explorer.omni.network:8545"
     default_start_block = 0
     confirmation_block_count = 0
-    syncInterval = 10
-    portal_addr = "0x1212400000000000000000000000000000000001"
+    sync_interval = 10
+    omni_predeploy_addr = "0x1212400000000000000000000000000000000001"
   }
   external_chains_testnet = [
     {
@@ -55,7 +55,7 @@ locals {
       rpc_addr = "https://optimism-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
       default_start_block = -1
       confirmation_block_count = 10
-      syncInterval = 30
+      sync_interval = 30
       portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
     },
     {
@@ -63,7 +63,7 @@ locals {
       rpc_addr = "https://arbitrum-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
       default_start_block = -1
       confirmation_block_count = 10
-      syncInterval = 30
+      sync_interval = 30
       portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
     },
     {
@@ -71,7 +71,7 @@ locals {
       rpc_addr = "https://linea-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
       default_start_block = -1
       confirmation_block_count = 10
-      syncInterval = 30
+      sync_interval = 30
       portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
     },
     {
@@ -79,7 +79,7 @@ locals {
       rpc_addr = "http://archive-node.sepolia.scroll.xyz:8545"
       default_start_block = -1
       confirmation_block_count = 10
-      syncInterval = 30
+      sync_interval = 30
       portal_addr = "0xcbbc5Da52ea2728279560Dca8f4ec08d5F829985"
     }
   ]

--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ module "obs_staging_vpc" {
   xchain_settings = {
     enabled             = true
     docker_image        = local.xchain_indexer_staging_docker_image
+    config_file_path    = "/config/config.json"
     config_file_content = jsonencode({
       omni_config = local.omni_chain_config_staging,
       external_chains = [
@@ -143,6 +144,7 @@ module "obs_testnet_vpc" {
   xchain_settings = {
     enabled             = true
     docker_image        = local.xchain_indexer_testnet_docker_image
+    config_file_path    = "/config/config.json"
     config_file_content = jsonencode({
       omni_config = local.omni_chain_config_testnet,
       external_chains = [

--- a/main.tf
+++ b/main.tf
@@ -99,16 +99,12 @@ module "obs_staging_vpc" {
   xchain_settings = {
     enabled             = true
     docker_image        = local.xchain_indexer_staging_docker_image
-    config_file_name    = "config"
     config_file_content = jsonencode({
       omni_config = local.omni_chain_config_staging,
       external_chains = [
         for x_chain in local.external_chains_staging : x_chain
       ]
     })
-    omni_config      = {
-      omni_rpc = local.omni_chain_config_staging.rpc_addr
-    }
   }
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_staging_docker_image
@@ -147,16 +143,12 @@ module "obs_testnet_vpc" {
   xchain_settings = {
     enabled             = true
     docker_image        = local.xchain_indexer_testnet_docker_image
-    config_file_name    = "testnet"
     config_file_content = jsonencode({
       omni_config = local.omni_chain_config_testnet,
       external_chains = [
         for x_chain in local.external_chains_testnet : x_chain
       ]
     })
-    omni_config      = {
-      omni_rpc = local.omni_chain_config_testnet.rpc_addr
-    }
   }
   blockscout_settings = {
     blockscout_docker_image = local.blockscout_testnet_docker_image


### PR DESCRIPTION
Wrapping up remaining work for allowing the indexer to support additional chains with a simple config change. This PR goes together with[ this one ](https://github.com/omni-network/xchain-indexer/pull/18)from x-indexer repo.

Changes:

- Removing  xchain_config_file_name as now only a single config file will be mounted
 
- Removing omni_config.omni_rpc as it was used for  testing
 
- Renaming syncInterval to sync_interval for consistency
 
- Renaming omni.config.portal_addr to omni_config.omni_predeploy_addr to better reflect the variable usage

From my understanding of TF, this would be a breaking change. If both x-indexer docker images (staging and testnet) are not updated with the results of[ this PR](https://github.com/omni-network/xchain-indexer/pull/18), we would have failure of the deployment for the environment where the image is not applied.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205273574816497