### PR TITLE
fix: api path in examples

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -295,6 +295,7 @@ module "ec2_asg_api_and_ui" {
     sig_provider_service_url      = var.sig_provider_enabled ? module.alb_sig_provider[0].lb_dns_name : var.blockscout_settings["sig_provider_service_url"]
     indexer                       = false
     api_and_ui                    = true
+    blockscout_host               = var.blockscout_settings["blockscout_host"]
   }
   tags = local.final_tags
 }

--- a/aws/templates/docker_compose.tftpl
+++ b/aws/templates/docker_compose.tftpl
@@ -34,7 +34,7 @@ services:
       DISABLE_WRITE_API: "true"
 %{ endif ~}
       BLOCKSCOUT_PROTOCOL: "https"
-      BLOCKSCOUT_HOST: "testnet.explorer.omni.network/"
+      BLOCKSCOUT_HOST: '${blockscout_host}'
       BLOCKSCOUT_VERSION: v5.2.2
       ETHEREUM_JSONRPC_TRACE_URL: '${rpc_address}'
       ETHEREUM_JSONRPC_HTTP_URL: '${rpc_address}'

--- a/aws/templates/docker_compose.tftpl
+++ b/aws/templates/docker_compose.tftpl
@@ -33,6 +33,8 @@ services:
       DISABLE_READ_API: "true"
       DISABLE_WRITE_API: "true"
 %{ endif ~}
+      BLOCKSCOUT_PROTOCOL: "https"
+      BLOCKSCOUT_HOST: "testnet.explorer.omni.network/"
       BLOCKSCOUT_VERSION: v5.2.2
       ETHEREUM_JSONRPC_TRACE_URL: '${rpc_address}'
       ETHEREUM_JSONRPC_HTTP_URL: '${rpc_address}'

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -169,6 +169,7 @@ variable "blockscout_settings" {
     ws_address                    = optional(string, "")
     visualize_sol2uml_service_url = optional(string, "")
     sig_provider_service_url      = optional(string, "")
+    blockscout_host               = optional(string, "testnet.explorer.omni.network")
   })
   default = {}
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -169,7 +169,7 @@ variable "blockscout_settings" {
     ws_address                    = optional(string, "")
     visualize_sol2uml_service_url = optional(string, "")
     sig_provider_service_url      = optional(string, "")
-    blockscout_host               = optional(string, "testnet.explorer.omni.network")
+    blockscout_host               = optional(string, "staging.explorer.omni.network")
   })
   default = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ module "obs_staging_vpc" {
     ws_address              = local.omni_staging_ws
     chain_id                = "165"
     docker_shell            = "sh"
+    blockscout_host         = "staging.explorer.omni.network"
   }
   tags = {
     project           = "omni-staging-blockscout"
@@ -164,6 +165,7 @@ module "obs_testnet_vpc" {
     ws_address              = local.omni_testnet_ws
     chain_id                = "165"
     docker_shell            = "sh"
+    blockscout_host         = "testnet.explorer.omni.network"
   }
   tags = {
     project           = "omni-testnet-blockscout"


### PR DESCRIPTION
Add `BLOCKSCOUT_PROTOCOL` and `BLOCKSCOUT_HOST` environment variables.

Currently, our [testnet api docs](https://testnet.explorer.omni.network/api-docs) show "localhost:4000" as the base url for the api. This is incorrect. Using these as directed by the [blockscout docs](https://docs.blockscout.com/for-developers/information-and-settings/env-variables) and tested locally by running the [Omni blockscout repo](https://github.com/omni-network/blockscout/) docker compose up with these set.

https://app.asana.com/0/1201980002255967/1204820543658627/f