### PR TITLE
Move some values from main.tf to tfvars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,9 +41,9 @@ locals {
   xchain_indexer_staging_docker_image = "omniops/xchain-indexer:0.1.3"
   blockscout_staging_docker_image = "omniops/blockscout:0.1.0.commit.2404d446"
 
-  omni_testnet_ws = "ws://testnet-sentry-explorer.omni.network:8546"
+  omni_testnet_ws = "ws://${var.testnet_sentry_node_url}:8546"
   omni_chain_config_testnet = {
-    rpc_addr = "http://testnet-sentry-explorer.omni.network:8545"
+    rpc_addr = "http://${var.testnet_sentry_node_url}:8545"
     default_start_block = 0
     confirmation_block_count = 0
     sync_interval = 10
@@ -52,7 +52,7 @@ locals {
   external_chains_testnet = [
     {
       chain_name = "optimism-goerli"
-      rpc_addr = "https://optimism-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
+      rpc_addr = "https://optimism-goerli.infura.io/v3/${var.infura_api_key}"
       default_start_block = -1
       confirmation_block_count = 10
       sync_interval = 30
@@ -60,7 +60,7 @@ locals {
     },
     {
       chain_name = "arbitrum-goerli"
-      rpc_addr = "https://arbitrum-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
+      rpc_addr = "https://arbitrum-goerli.infura.io/v3/${var.infura_api_key}"
       default_start_block = -1
       confirmation_block_count = 10
       sync_interval = 30
@@ -68,7 +68,7 @@ locals {
     },
     {
       chain_name = "linea-goerli"
-      rpc_addr = "https://linea-goerli.infura.io/v3/1e8b7c7931d24be095e34d0177c14854"
+      rpc_addr = "https://linea-goerli.infura.io/v3/${var.infura_api_key}"
       default_start_block = -1
       confirmation_block_count = 10
       sync_interval = 30

--- a/secrets.auto.tfvars.sample
+++ b/secrets.auto.tfvars.sample
@@ -1,2 +1,3 @@
-infura_api_key = "<located_in_...>"
-testnet_sentry_node_url = "<located_in_...>"
+infura_api_key = "<Infura shared API key named omni-indexer>"
+testnet_sentry_node_url = "<Ask a team member>"
+cloudflare_api_token = "<API token from our Cloudflare account>"

--- a/secrets.auto.tfvars.sample
+++ b/secrets.auto.tfvars.sample
@@ -1,0 +1,2 @@
+infura_api_key = "<located_in_...>"
+testnet_sentry_node_url = "<located_in_...>"

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,11 @@
+variable "infura_api_key" {
+    description = "Infura api key used for talking to external chains"
+    type = string
+    sensitive = true
+}
+
+variable "testnet_sentry_node_url" {
+    description = "URL of the testnet sentry node"
+    type = string
+    sensitive = true
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,11 +1,17 @@
 variable "infura_api_key" {
     description = "Infura api key used for talking to external chains"
-    type = string
-    sensitive = true
+    type        = string
+    sensitive   = true
 }
 
 variable "testnet_sentry_node_url" {
     description = "URL of the testnet sentry node"
-    type = string
-    sensitive = true
+    type        = string
+    sensitive   = true
+}
+
+variable "cloudflare_api_token" {
+    description = "The Cloudflare API token."
+    type        = string
+    sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "cloudflare_api_token" {
-  description = "The Cloudflare API token."
-  type        = string
-}
-
 variable "cloudflare_zone_id" {
   description = "The Cloudflare zone ID."
   type        = string


### PR DESCRIPTION
Moved sentry url and infura api key to tfvars.
Intentionally placed these variables into a separate .tf file to make them explicit.(this is why *.auto.tfvars naming convention is used)
Added a sample tfvars file that should hold values for these variables 

Requires a local secrets.auto.tfvars with proper values in order to be able to perform apply.
*auto.tfvars is already part of .gitignore