### PR TITLE
tune rds instance types

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -180,7 +180,8 @@ module "rds" {
   create_cloudwatch_log_group         = false
   backup_retention_period             = 7
   skip_final_snapshot                 = true
-  deletion_protection                 = false
+  deletion_protection                 = false # TODO(corver): This should probably be true for testnet and mainnet.
+  performance_insights_enabled        = true
   tags                                = local.final_tags
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -10,9 +10,10 @@ variable "deploy_ec2_instance_db" {
   default     = true
 }
 variable "rds_instance_type" {
+  #required if deploy_rds_db=true
   description = "AWS RDS instance type"
   type        = string
-  default     = "db.t3.large"
+  default     = ""
 }
 variable "rds_allocated_storage" {
   description = "Size of rds storage"
@@ -145,10 +146,10 @@ variable "single_nat_gateway" {
 variable "xchain_settings" {
   description = "Settings of verifier"
   type = object({
-    enabled                     = optional(bool, false)
-    docker_image                = optional(string, "omniops/xchain-indexer:latest")
-    config_file_path            = optional(string, "/config/config.json")
-    config_file_content         = optional(string, "")
+    enabled             = optional(bool, false)
+    docker_image        = optional(string, "omniops/xchain-indexer:latest")
+    config_file_path    = optional(string, "/config/config.json")
+    config_file_content = optional(string, "")
   })
   default = {}
 }
@@ -162,7 +163,7 @@ variable "agent_secret_file_content" {
 
 variable "agent_env" {
   description = "Grafana Agent env label"
-  type = string
+  type        = string
 }
 
 ## Blockscout settings

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,8 @@ module "obs_staging_vpc" {
   ssl_certificate_arn                    = var.ssl_certificate_arn
   create_iam_instance_profile_ssm_policy = "true"
   deploy_ec2_instance_db                 = false
-  deploy_rds_db                          = true
+  deploy_rds_db                          = true # TODO(corver): Staging probably doesn't require a long-lived rds instance.
+  rds_instance_type                      = "db.t4g.micro"
   xchain_settings = {
     enabled             = true
     docker_image        = local.xchain_indexer_staging_docker_image
@@ -156,6 +157,7 @@ module "obs_testnet_vpc" {
   create_iam_instance_profile_ssm_policy = "true"
   deploy_ec2_instance_db                 = false
   deploy_rds_db                          = true
+  rds_instance_type                      = "db.t4g.xlarge"
   xchain_settings = {
     enabled             = true
     docker_image        = local.xchain_indexer_testnet_docker_image


### PR DESCRIPTION
Increases testnet rds instance size since it was completely overloaded (CPU).

Decrease staging tds instance size since it was completely under utilised (everything)

Switching from T3 to T4g since they are [cheaper and more performant](https://www.learnaws.org/2020/12/19/t3-t3a-t4g/)